### PR TITLE
fix nxos_vrf ansible which does not highlight commands diff

### DIFF
--- a/plugins/modules/nxos_vrf.py
+++ b/plugins/modules/nxos_vrf.py
@@ -627,11 +627,12 @@ def main():
     commands = map_obj_to_commands((want, have), module)
     result["commands"] = commands
 
-    if commands and not module.check_mode:
-        responses = load_config(
-            module, commands, opts={"catch_clierror": True}
-        )
-        vrf_error_check(module, commands, responses)
+    if commands:
+        if not module.check_mode:
+            responses = load_config(
+                module, commands, opts={"catch_clierror": True}
+            )
+            vrf_error_check(module, commands, responses)
         result["changed"] = True
 
     check_declarative_intent_params(want, module, element_spec, result)


### PR DESCRIPTION
Currently nxos_vrf could not correctly show the changed commands with highlighted message, which confuses people. This pr fixes the changed determination logic for nxos_vrf module.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
